### PR TITLE
Fix a few bugs

### DIFF
--- a/lib/webidl/parser/idl.treetop
+++ b/lib/webidl/parser/idl.treetop
@@ -74,8 +74,12 @@ module WebIDL
         (eal:ExtendedAttributeList ws member:DictionaryMember ws members:DictionaryMembers <ParseTree::DictionaryMembers>)?
       end
 
+      rule Required
+        "required"
+      end
+
       rule DictionaryMember
-        type:Type ws name:identifier ws default:Default ws ";" <ParseTree::DictionaryMember>
+        required:Required? ws type:Type ws name:identifier ws default:Default ws ";" <ParseTree::DictionaryMember>
       end
 
       rule Default
@@ -442,7 +446,7 @@ module WebIDL
       end
 
       rule PromiseType
-         "Promise" "<" return_type:ReturnType ">" {
+         "Promise" ws "<" ws return_type:ReturnType ws ">" {
             def build(parent)
               Ast::PromiseType.new(return_type.text_value)
             end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -3,6 +3,53 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 describe WebIDL::Parser::IDLParser do
 
   #
+  # dictionaries
+  #
+
+  it "parses an empty dictionary" do
+    str = <<-IDL
+      dictionary Foo {};
+    IDL
+    parse(str).should_not be_nil
+  end
+
+  it "parses dictionary members" do
+    str = <<-IDL
+      dictionary Foo { DOMString foo; };
+    IDL
+    parse(str).should_not be_nil
+  end
+
+  it "parses required dictionary members" do
+    str = <<-IDL
+      dictionary Foo { required DOMString foo; };
+    IDL
+    parse(str).should_not be_nil
+  end
+
+  #
+  # promises
+  #
+
+  it "parses empty promises" do
+    str = <<-IDL
+      interface Asdf {
+        Promise <DOMString> doSomething ();
+      };
+    IDL
+    parse(str).should_not be_nil
+  end
+
+  it "parses promises with ws around return type" do
+    str = <<-IDL
+      interface Asdf {
+        Promise < DOMString > doSomething ();
+      };
+    IDL
+    parse(str).should_not be_nil
+  end
+
+  #
   # interfaces
   #
 


### PR DESCRIPTION
This PR fixes two bugs:

- Whitespace wasn't allowed around the return type from a promise.
- Dictionary members couldn't be prefixed with the `required` keyword.

These fixes allow this gem to parse the IDL from the [Web Authentication](https://w3c.github.io/webauthn/#api) spec.